### PR TITLE
Fix imports of own packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/factorycampus/radau v0.0.0-20181018113934-aa422cae6f27
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-pg/migrations v6.5.0+incompatible

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/factorycampus/radau/api"
-	"github.com/factorycampus/radau/migrations"
+	"github.com/FactoryCampus/radau/api"
+	"github.com/FactoryCampus/radau/migrations"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/go-pg/pg"


### PR DESCRIPTION
The module name should not include the full GitHub path because local development will not be possible.
Instead of using the local files go will always use the sources from GitHub.
Removing the full GitHub path from the module name solves this issue.